### PR TITLE
Prevent double-destroy of queue in __dealloc__

### DIFF
--- a/netfilterqueue.pyx
+++ b/netfilterqueue.pyx
@@ -170,6 +170,7 @@ cdef class NetfilterQueue:
         """Destroy the queue."""
         if self.qh != NULL:
             nfq_destroy_queue(self.qh)
+        self.qh = NULL
         # See warning about nfq_unbind_pf in __dealloc__ above.
         
     def run(self):


### PR DESCRIPTION
If the user calls unbind, the queue is destroyed.

When the GC then runs again the queue is destroyed incorrectly in __dealloc__