### PR TITLE
Remove unnecessary conversion of byte order for set_mark

### DIFF
--- a/netfilterqueue.c
+++ b/netfilterqueue.c
@@ -2148,7 +2148,7 @@ static void __pyx_f_14netfilterqueue_6Packet_verdict(struct __pyx_obj_14netfilte
  *                 self._qh,
  *                 self.id,
  */
-    nfq_set_verdict2(__pyx_v_self->_qh, __pyx_v_self->id, __pyx_v_verdict, htonl(__pyx_v_self->_given_mark), __pyx_v_modified_payload_len, __pyx_v_modified_payload);
+    nfq_set_verdict2(__pyx_v_self->_qh, __pyx_v_self->id, __pyx_v_verdict, __pyx_v_self->_given_mark, __pyx_v_modified_payload_len, __pyx_v_modified_payload);
 
     /* "netfilterqueue.pyx":82
  *             modified_payload_len = len(self._given_payload)

--- a/netfilterqueue.pyx
+++ b/netfilterqueue.pyx
@@ -84,7 +84,7 @@ cdef class Packet:
                 self._qh,
                 self.id,
                 verdict,
-                htonl(self._given_mark),
+                self._given_mark,
                 modified_payload_len,
                 modified_payload)
         else:


### PR DESCRIPTION
As nfq_set_verdict2 coverts byte order of "mark" (unlike
nfq_set_verdict_mark), we have not to do it on our own.
Otherwise, for example, Packet.set_mark(0x1234) results in
0x34120000 on little-endian machines.
