### PR TITLE
#define PyString_FromStringAndSize -> PyUnicode_FromStringAndSize

### DIFF
--- a/netfilterqueue.c
+++ b/netfilterqueue.c
@@ -266,6 +266,7 @@
   #define PyString_Type                PyUnicode_Type
   #define PyString_Check               PyUnicode_Check
   #define PyString_CheckExact          PyUnicode_CheckExact
+  #define PyString_FromStringAndSize   PyUnicode_FromStringAndSize
 #endif
 #if PY_MAJOR_VERSION >= 3
   #define __Pyx_PyBaseString_Check(obj) PyUnicode_Check(obj)


### PR DESCRIPTION
In Opensnitch we had some Gentoo users with issues related to this (https://github.com/evilsocket/opensnitch/issues/69). 